### PR TITLE
Extract entries (to path)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -312,6 +312,13 @@ impl ArchiveEntryReader {
         Reader { handler: self.handler.clone() }
     }
 
+    pub fn extract_to(self, path : &str) -> Result<Self, ArchiveError> {
+        let extract_path = CString::new(path).unwrap();
+        unsafe {
+            archive_entry_set_pathname(self.entry, extract_path.as_ptr());
+            self.extract()
+        }
+    }
     pub fn extract(self) -> Result<Self, ArchiveError> {        
         unsafe {
           let res = archive_read_extract(*self.handler, self.entry, 0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -312,6 +312,18 @@ impl ArchiveEntryReader {
         Reader { handler: self.handler.clone() }
     }
 
+    pub fn extract(self) -> Result<Self, ArchiveError> {        
+        unsafe {
+          let res = archive_read_extract(*self.handler, self.entry, 0);
+          if res==ARCHIVE_OK {
+              Ok(self)
+          } else {
+            Err(code_to_error(res))
+          }
+        }
+    }
+
+
     get_time!(access_time, atime);
     get_time!(creation_time, birthtime);
     get_time!(inode_change_time, ctime);


### PR DESCRIPTION
As I also needed to extract entries after reading in the archive, I added two high level methods that perform the extraction:
- ArchiveEntryReader::extract
- ArchiveEntryReader::extract_to

where the first just maps into the native libarchive extract, and the second performs a "destination path" set step, so that you can extract the entry to any path of choice.
