### PR TITLE
libarchive now builds with the latest rust nightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 #![feature(trace_macros)]
 #![feature(concat_idents)]
 #![feature(box_raw)]
-#![feature(rc_unique)]
+#![feature(rc_counts)]
 
 
 mod ffi;


### PR DESCRIPTION
Latest nightly was failing to build, this was the short-term workaround I found by following the compiler error messages.

There are also a high number of new warnings that probably need to be addressed next.
