### PR TITLE
Update to rustc v 1.90

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: rust
+rust: nightly
+sudo: false
+addons:
+  apt:
+    packages:
+      - libarchive-dev

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository="https://github.com/tz-lom/libarchive-sys"
 build = "build.rs"
 
 [dependencies]
-time="*"
+time="0.2"
 
 [lib]
 name = "Archive"

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 [![Build Status](https://secure.travis-ci.org/dginev/libarchive-sys.png?branch=master)](http://travis-ci.org/dginev/libarchive-sys)
+
+**NOTE:** this crate is maintained for backwards compatibility only, please use the chef-authored crate for any new work, located at https://crates.io/crates/libarchive

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
 [![Build Status](https://secure.travis-ci.org/dginev/libarchive-sys.png?branch=master)](http://travis-ci.org/dginev/libarchive-sys)
 
+Minimal required rustc:
+```
+cargo 1.90.0-nightly (84709f085 2025-06-22)
+```
+
 **NOTE:** this crate is maintained for backwards compatibility only, please use the chef-authored crate for any new work, located at https://crates.io/crates/libarchive

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Build Status](https://secure.travis-ci.org/dginev/libarchive-sys.png?branch=master)](http://travis-ci.org/dginev/libarchive-sys)

--- a/src/ffi/archive.rs
+++ b/src/ffi/archive.rs
@@ -3,16 +3,13 @@ extern crate libc;
 
 pub use self::libc::{c_void, c_int, c_uint, c_char, c_long, c_ulong, int64_t, ssize_t, wchar_t, size_t, time_t, FILE, stat, dev_t, mode_t};
 
-#[repr(C)]
-pub struct Struct_archive;
-#[repr(C)]
-pub struct Struct_archive_entry;
-#[repr(C)]
-pub struct Struct_stat;
-#[repr(C)]
-pub struct Struct_archive_acl;
-#[repr(C)]
-pub struct Struct_archive_entry_linkresolver;
+// empty enums seem to be the recommended state I could find, see:
+// https://github.com/rust-lang/rust/issues/27303
+pub enum Struct_archive {}
+pub enum Struct_archive_entry {}
+pub enum Struct_stat {}
+pub enum Struct_archive_acl {}
+pub enum Struct_archive_entry_linkresolver {}
 
 pub type archive_read_callback =
     extern "C" fn(arg1: *mut Struct_archive,
@@ -21,7 +18,7 @@ pub type archive_read_callback =
 pub type archive_skip_callback =
     extern "C" fn(arg1: *mut Struct_archive,
                   _client_data: *mut c_void, request: int64_t)
-        -> int64_t; 
+        -> int64_t;
 pub type archive_seek_callback =
     extern "C" fn(arg1: *mut Struct_archive,
                   _client_data: *mut c_void, offset: int64_t,

--- a/src/ffi/archive.rs
+++ b/src/ffi/archive.rs
@@ -1,7 +1,7 @@
 
 extern crate libc;
 
-pub use self::libc::{c_void, c_int, c_uint, c_char, c_long, c_ulong, int64_t, ssize_t, wchar_t, size_t, time_t, FILE, stat, dev_t, mode_t};
+pub use self::libc::{c_void, c_int, c_uint, c_char, c_long, c_ulong, ssize_t, wchar_t, size_t, time_t, FILE, stat, dev_t, mode_t};
 
 // empty enums seem to be the recommended state I could find, see:
 // https://github.com/rust-lang/rust/issues/27303
@@ -17,12 +17,12 @@ pub type archive_read_callback =
                   _buffer: *mut *mut c_void) -> ssize_t;
 pub type archive_skip_callback =
     extern "C" fn(arg1: *mut Struct_archive,
-                  _client_data: *mut c_void, request: int64_t)
-        -> int64_t;
+                  _client_data: *mut c_void, request: i64)
+        -> i64;
 pub type archive_seek_callback =
     extern "C" fn(arg1: *mut Struct_archive,
-                  _client_data: *mut c_void, offset: int64_t,
-                  whence: c_int) -> int64_t;
+                  _client_data: *mut c_void, offset: i64,
+                  whence: c_int) -> i64;
 
 pub type archive_write_callback =
     extern "C" fn(arg1: *mut Struct_archive,
@@ -226,13 +226,13 @@ extern "C" {
                                           arg2:
                                               *mut ::std::option::Option<extern "C" fn()
                                                                              ->
-                                                                                 int64_t>)
+                                                                                 i64>)
      -> c_int;
      pub fn archive_read_set_skip_callback(arg1: *mut Struct_archive,
                                           arg2:
                                               *mut ::std::option::Option<extern "C" fn()
                                                                              ->
-                                                                                 int64_t>)
+                                                                                 i64>)
      -> c_int;
      pub fn archive_read_set_close_callback(arg1: *mut Struct_archive,
                                            arg2:
@@ -297,7 +297,7 @@ extern "C" {
                                   *mut ::std::option::Option<extern "C" fn(arg1: *mut Struct_archive,
                                                                             _client_data: *mut c_void,
                                                                             _buffer: *mut *const c_void)
-                                                                 -> int64_t>,
+                                                                 -> i64>,
                               arg5:
                                   *mut ::std::option::Option<extern "C" fn(arg1: *mut Struct_archive,
                                                                             _client_data: *mut c_void)
@@ -332,15 +332,15 @@ extern "C" {
      pub fn archive_read_next_header2(arg1: *mut Struct_archive,
                                      arg2: *mut Struct_archive_entry)
      -> c_int;
-     pub fn archive_read_header_position(arg1: *mut Struct_archive) -> int64_t;
+     pub fn archive_read_header_position(arg1: *mut Struct_archive) -> i64;
      pub fn archive_read_data(arg1: *mut Struct_archive,
                              arg2: *mut c_void, arg3: size_t)
      -> ssize_t;
-     pub fn archive_seek_data(arg1: *mut Struct_archive, arg2: int64_t,
-                             arg3: c_int) -> int64_t;
+     pub fn archive_seek_data(arg1: *mut Struct_archive, arg2: i64,
+                             arg3: c_int) -> i64;
      pub fn archive_read_data_block(a: *mut Struct_archive,
                                    buff: *mut *const c_void,
-                                   size: *mut size_t, offset: *mut int64_t)
+                                   size: *mut size_t, offset: *mut i64)
      -> c_int;
      pub fn archive_read_data_skip(arg1: *mut Struct_archive) -> c_int;
      pub fn archive_read_data_into_fd(arg1: *mut Struct_archive,
@@ -379,7 +379,7 @@ extern "C" {
                                                           *mut c_void)
      -> ();
      pub fn archive_read_extract_set_skip_file(arg1: *mut Struct_archive,
-                                              arg2: int64_t, arg3: int64_t)
+                                              arg2: i64, arg3: i64)
      -> ();
      pub fn archive_read_close(arg1: *mut Struct_archive) -> c_int;
      pub fn archive_read_free(arg1: *mut Struct_archive) -> c_int;
@@ -397,7 +397,7 @@ extern "C" {
      pub fn archive_write_get_bytes_in_last_block(arg1: *mut Struct_archive)
      -> c_int;
      pub fn archive_write_set_skip_file(arg1: *mut Struct_archive,
-                                       arg2: int64_t, arg3: int64_t)
+                                       arg2: i64, arg3: i64)
      -> c_int;
      pub fn archive_write_set_compression_bzip2(arg1: *mut Struct_archive)
      -> c_int;
@@ -533,7 +533,7 @@ extern "C" {
      -> ssize_t;
      pub fn archive_write_data_block(arg1: *mut Struct_archive,
                                     arg2: *const c_void, arg3: size_t,
-                                    arg4: int64_t) -> ssize_t;
+                                    arg4: i64) -> ssize_t;
      pub fn archive_write_finish_entry(arg1: *mut Struct_archive)
      -> c_int;
      pub fn archive_write_close(arg1: *mut Struct_archive) -> c_int;
@@ -560,7 +560,7 @@ extern "C" {
      -> c_int;
      pub fn archive_write_disk_new() -> *mut Struct_archive;
      pub fn archive_write_disk_set_skip_file(arg1: *mut Struct_archive,
-                                            arg2: int64_t, arg3: int64_t)
+                                            arg2: i64, arg3: i64)
      -> c_int;
      pub fn archive_write_disk_set_options(arg1: *mut Struct_archive,
                                           flags: c_int)
@@ -575,9 +575,9 @@ extern "C" {
                                                                                        arg2:
                                                                                            *const c_char,
                                                                                        arg3:
-                                                                                           int64_t)
+                                                                                           i64)
                                                                              ->
-                                                                                 int64_t>,
+                                                                                 i64>,
                                                arg4:
                                                    ::std::option::Option<extern "C" fn(arg1:
                                                                                            *mut c_void)
@@ -592,9 +592,9 @@ extern "C" {
                                                                                       arg2:
                                                                                           *const c_char,
                                                                                       arg3:
-                                                                                          int64_t)
+                                                                                          i64)
                                                                             ->
-                                                                                int64_t>,
+                                                                                i64>,
                                               arg4:
                                                   ::std::option::Option<extern "C" fn(arg1:
                                                                                           *mut c_void)
@@ -602,11 +602,11 @@ extern "C" {
                                                                                 ()>)
      -> c_int;
      pub fn archive_write_disk_gid(arg1: *mut Struct_archive,
-                                  arg2: *const c_char, arg3: int64_t)
-     -> int64_t;
+                                  arg2: *const c_char, arg3: i64)
+     -> i64;
      pub fn archive_write_disk_uid(arg1: *mut Struct_archive,
-                                  arg2: *const c_char, arg3: int64_t)
-     -> int64_t;
+                                  arg2: *const c_char, arg3: i64)
+     -> i64;
      pub fn archive_read_disk_new() -> *mut Struct_archive;
      pub fn archive_read_disk_set_symlink_logical(arg1: *mut Struct_archive)
      -> c_int;
@@ -619,9 +619,9 @@ extern "C" {
                                              arg3: c_int,
                                              arg4: *const stat)
      -> c_int;
-     pub fn archive_read_disk_gname(arg1: *mut Struct_archive, arg2: int64_t)
+     pub fn archive_read_disk_gname(arg1: *mut Struct_archive, arg2: i64)
      -> *const c_char;
-     pub fn archive_read_disk_uname(arg1: *mut Struct_archive, arg2: int64_t)
+     pub fn archive_read_disk_uname(arg1: *mut Struct_archive, arg2: i64)
      -> *const c_char;
      pub fn archive_read_disk_set_standard_lookup(arg1: *mut Struct_archive)
      -> c_int;
@@ -631,7 +631,7 @@ extern "C" {
                                                   ::std::option::Option<extern "C" fn(arg1:
                                                                                           *mut c_void,
                                                                                       arg2:
-                                                                                          int64_t)
+                                                                                          i64)
                                                                             ->
                                                                                 *const c_char>,
                                               arg4:
@@ -646,7 +646,7 @@ extern "C" {
                                                   ::std::option::Option<extern "C" fn(arg1:
                                                                                           *mut c_void,
                                                                                       arg2:
-                                                                                          int64_t)
+                                                                                          i64)
                                                                             ->
                                                                                 *const c_char>,
                                               arg4:
@@ -706,14 +706,14 @@ extern "C" {
      -> c_int;
      pub fn archive_filter_count(arg1: *mut Struct_archive) -> c_int;
      pub fn archive_filter_bytes(arg1: *mut Struct_archive,
-                                arg2: c_int) -> int64_t;
+                                arg2: c_int) -> i64;
      pub fn archive_filter_code(arg1: *mut Struct_archive, arg2: c_int)
      -> c_int;
      pub fn archive_filter_name(arg1: *mut Struct_archive, arg2: c_int)
      -> *const c_char;
-     pub fn archive_position_compressed(arg1: *mut Struct_archive) -> int64_t;
+     pub fn archive_position_compressed(arg1: *mut Struct_archive) -> i64;
      pub fn archive_position_uncompressed(arg1: *mut Struct_archive)
-     -> int64_t;
+     -> i64;
      pub fn archive_compression_name(arg1: *mut Struct_archive)
      -> *const c_char;
      pub fn archive_compression(arg1: *mut Struct_archive) -> c_int;
@@ -814,9 +814,9 @@ extern "C" {
      pub fn archive_match_owner_excluded(arg1: *mut Struct_archive,
                                         arg2: *mut Struct_archive_entry)
      -> c_int;
-     pub fn archive_match_include_uid(arg1: *mut Struct_archive, arg2: int64_t)
+     pub fn archive_match_include_uid(arg1: *mut Struct_archive, arg2: i64)
      -> c_int;
-     pub fn archive_match_include_gid(arg1: *mut Struct_archive, arg2: int64_t)
+     pub fn archive_match_include_gid(arg1: *mut Struct_archive, arg2: i64)
      -> c_int;
      pub fn archive_match_include_uname(arg1: *mut Struct_archive,
                                        arg2: *const c_char)
@@ -865,7 +865,7 @@ extern "C" {
                                 arg3: *mut c_ulong) -> ();
      pub fn archive_entry_fflags_text(arg1: *mut Struct_archive_entry)
      -> *const c_char;
-     pub fn archive_entry_gid(arg1: *mut Struct_archive_entry) -> int64_t;
+     pub fn archive_entry_gid(arg1: *mut Struct_archive_entry) -> i64;
      pub fn archive_entry_gname(arg1: *mut Struct_archive_entry)
      -> *const c_char;
      pub fn archive_entry_gname_w(arg1: *mut Struct_archive_entry)
@@ -874,8 +874,8 @@ extern "C" {
      -> *const c_char;
      pub fn archive_entry_hardlink_w(arg1: *mut Struct_archive_entry)
      -> *const wchar_t;
-     pub fn archive_entry_ino(arg1: *mut Struct_archive_entry) -> int64_t;
-     pub fn archive_entry_ino64(arg1: *mut Struct_archive_entry) -> int64_t;
+     pub fn archive_entry_ino(arg1: *mut Struct_archive_entry) -> i64;
+     pub fn archive_entry_ino64(arg1: *mut Struct_archive_entry) -> i64;
      pub fn archive_entry_ino_is_set(arg1: *mut Struct_archive_entry)
      -> c_int;
      pub fn archive_entry_mode(arg1: *mut Struct_archive_entry) -> mode_t;
@@ -898,7 +898,7 @@ extern "C" {
      -> *const c_char;
      pub fn archive_entry_sourcepath_w(arg1: *mut Struct_archive_entry)
      -> *const wchar_t;
-     pub fn archive_entry_size(arg1: *mut Struct_archive_entry) -> int64_t;
+     pub fn archive_entry_size(arg1: *mut Struct_archive_entry) -> i64;
      pub fn archive_entry_size_is_set(arg1: *mut Struct_archive_entry)
      -> c_int;
      pub fn archive_entry_strmode(arg1: *mut Struct_archive_entry)
@@ -907,7 +907,7 @@ extern "C" {
      -> *const c_char;
      pub fn archive_entry_symlink_w(arg1: *mut Struct_archive_entry)
      -> *const wchar_t;
-     pub fn archive_entry_uid(arg1: *mut Struct_archive_entry) -> int64_t;
+     pub fn archive_entry_uid(arg1: *mut Struct_archive_entry) -> i64;
      pub fn archive_entry_uname(arg1: *mut Struct_archive_entry)
      -> *const c_char;
      pub fn archive_entry_uname_w(arg1: *mut Struct_archive_entry)
@@ -941,7 +941,7 @@ extern "C" {
                                             arg2: *const wchar_t)
      -> *const wchar_t;
      pub fn archive_entry_set_gid(arg1: *mut Struct_archive_entry,
-                                 arg2: int64_t) -> ();
+                                 arg2: i64) -> ();
      pub fn archive_entry_set_gname(arg1: *mut Struct_archive_entry,
                                    arg2: *const c_char) -> ();
      pub fn archive_entry_copy_gname(arg1: *mut Struct_archive_entry,
@@ -961,9 +961,9 @@ extern "C" {
                                               arg2: *const c_char)
      -> c_int;
      pub fn archive_entry_set_ino(arg1: *mut Struct_archive_entry,
-                                 arg2: int64_t) -> ();
+                                 arg2: i64) -> ();
      pub fn archive_entry_set_ino64(arg1: *mut Struct_archive_entry,
-                                   arg2: int64_t) -> ();
+                                   arg2: i64) -> ();
      pub fn archive_entry_set_link(arg1: *mut Struct_archive_entry,
                                   arg2: *const c_char) -> ();
      pub fn archive_entry_copy_link(arg1: *mut Struct_archive_entry,
@@ -998,7 +998,7 @@ extern "C" {
      pub fn archive_entry_set_rdevminor(arg1: *mut Struct_archive_entry,
                                        arg2: dev_t) -> ();
      pub fn archive_entry_set_size(arg1: *mut Struct_archive_entry,
-                                  arg2: int64_t) -> ();
+                                  arg2: i64) -> ();
      pub fn archive_entry_unset_size(arg1: *mut Struct_archive_entry) -> ();
      pub fn archive_entry_copy_sourcepath(arg1: *mut Struct_archive_entry,
                                          arg2: *const c_char) -> ();
@@ -1014,7 +1014,7 @@ extern "C" {
                                              arg2: *const c_char)
      -> c_int;
      pub fn archive_entry_set_uid(arg1: *mut Struct_archive_entry,
-                                 arg2: int64_t) -> ();
+                                 arg2: i64) -> ();
      pub fn archive_entry_set_uname(arg1: *mut Struct_archive_entry,
                                    arg2: *const c_char) -> ();
      pub fn archive_entry_copy_uname(arg1: *mut Struct_archive_entry,
@@ -1091,13 +1091,13 @@ extern "C" {
                                     arg4: *mut size_t) -> c_int;
      pub fn archive_entry_sparse_clear(arg1: *mut Struct_archive_entry) -> ();
      pub fn archive_entry_sparse_add_entry(arg1: *mut Struct_archive_entry,
-                                          arg2: int64_t, arg3: int64_t) -> ();
+                                          arg2: i64, arg3: i64) -> ();
      pub fn archive_entry_sparse_count(arg1: *mut Struct_archive_entry)
      -> c_int;
      pub fn archive_entry_sparse_reset(arg1: *mut Struct_archive_entry)
      -> c_int;
      pub fn archive_entry_sparse_next(arg1: *mut Struct_archive_entry,
-                                     arg2: *mut int64_t, arg3: *mut int64_t)
+                                     arg2: *mut i64, arg3: *mut i64)
      -> c_int;
      pub fn archive_entry_linkresolver_new()
      -> *mut Struct_archive_entry_linkresolver;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,9 +170,9 @@ fn flags_to_code(flags: Vec<ArchiveExtractFlag>) -> c_int {
 }
 
 struct ReadContainer {
-    reader: Box<Read>,
+    reader: Box<dyn Read>,
     buffer: Vec<u8>,
-    seeker: Option<Box<Seek>>,
+    seeker: Option<Box<dyn Seek>>,
 }
 
 impl ReadContainer {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -332,8 +332,13 @@ impl Drop for ArchiveEntryReader {
     use ArchiveEntryIOType::*;
     if Rc::is_unique(&self.handler) {
       match self.iotype {
-        ReaderEntry => unsafe { archive_read_free(*self.handler); },
-        WriterEntry => unsafe { archive_write_free(*self.handler); }
+        ReaderEntry => unsafe { 
+          archive_read_close(*self.handler);
+          archive_read_free(*self.handler); },
+        WriterEntry => unsafe {
+          archive_write_close(*self.handler);
+          archive_write_free(*self.handler); 
+        }
       }
     }
   }
@@ -342,7 +347,10 @@ impl Drop for ArchiveEntryReader {
 impl Drop for Reader {
 	fn drop(&mut self) {
 		if Rc::is_unique(&self.handler) {
-			unsafe { archive_read_free(*self.handler); }
+			unsafe { 
+        archive_read_close(*self.handler); 
+        archive_read_free(*self.handler); 
+      }
 		}
 	}
 }
@@ -358,6 +366,7 @@ impl Drop for Writer {
 	fn drop(&mut self) {
 		if Rc::is_unique(&self.handler) {
 			unsafe { 
+        archive_write_close(*self.handler); 
         archive_write_free(*self.handler); 
       }
 		}
@@ -526,7 +535,10 @@ impl WriterToDisk {
 impl Drop for WriterToDisk {
 	fn drop(&mut self) {
 		if Rc::is_unique(&self.handler) {
-			unsafe { archive_write_free(*self.handler); }
+			unsafe { 
+        archive_write_close(*self.handler); 
+        archive_write_free(*self.handler); 
+      }
 		}
 	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 
 #![feature(libc)]
+#![feature(is_unique)]
 
 //for debug purpose
 #![allow(dead_code)]
@@ -7,7 +8,6 @@
 #![allow(non_camel_case_types)]
 #![feature(trace_macros)]
 #![feature(concat_idents)]
-#![feature(rc_counts)]
 
 
 mod ffi;
@@ -106,7 +106,7 @@ pub enum ArchiveEntryFiletype {
   AE_IFCHR ,
   AE_IFBLK ,
   AE_IFDIR ,
-  AE_IFIFO 
+  AE_IFIFO
 }
 /*
 impl fmt::Debug for AllocationError {
@@ -330,12 +330,12 @@ impl Drop for ArchiveEntryReader {
     use ArchiveEntryIOType::*;
     if Rc::is_unique(&self.handler) {
       match self.iotype {
-        ReaderEntry => unsafe { 
+        ReaderEntry => unsafe {
           archive_read_close(*self.handler);
           archive_read_free(*self.handler); },
         WriterEntry => unsafe {
           archive_write_close(*self.handler);
-          archive_write_free(*self.handler); 
+          archive_write_free(*self.handler);
         }
       }
     }
@@ -345,9 +345,9 @@ impl Drop for ArchiveEntryReader {
 impl Drop for Reader {
 	fn drop(&mut self) {
 		if Rc::is_unique(&self.handler) {
-			unsafe { 
-        archive_read_close(*self.handler); 
-        archive_read_free(*self.handler); 
+			unsafe {
+        archive_read_close(*self.handler);
+        archive_read_free(*self.handler);
       }
 		}
 	}
@@ -362,9 +362,9 @@ pub struct Writer {
 impl Drop for Writer {
 	fn drop(&mut self) {
 		if Rc::is_unique(&self.handler) {
-			unsafe { 
-        archive_write_close(*self.handler); 
-        archive_write_free(*self.handler); 
+			unsafe {
+        archive_write_close(*self.handler);
+        archive_write_free(*self.handler);
       }
 		}
 	}
@@ -531,9 +531,9 @@ impl WriterToDisk {
 impl Drop for WriterToDisk {
 	fn drop(&mut self) {
 		if Rc::is_unique(&self.handler) {
-			unsafe { 
-        archive_write_close(*self.handler); 
-        archive_write_free(*self.handler); 
+			unsafe {
+        archive_write_close(*self.handler);
+        archive_write_free(*self.handler);
       }
 		}
 	}
@@ -615,7 +615,7 @@ impl ArchiveEntryReader {
             self.extract(flags)
         }
     }
-    pub fn extract(self,flags : Vec<ArchiveExtractFlag>) -> Result<Self, ArchiveError> {        
+    pub fn extract(self,flags : Vec<ArchiveExtractFlag>) -> Result<Self, ArchiveError> {
         unsafe {
           let res = archive_read_extract(*self.handler, self.entry, flags_to_code(flags));
           if res==ARCHIVE_OK {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,6 @@
 #![allow(non_camel_case_types)]
 #![feature(trace_macros)]
 #![feature(concat_idents)]
-#![feature(box_raw)]
 #![feature(rc_counts)]
 
 
@@ -251,7 +250,7 @@ impl Reader {
     }
 
 
-    pub fn open_filename(self, fileName: &str, bufferSize: u64 ) -> Result<Self, ArchiveError> {
+    pub fn open_filename(self, fileName: &str, bufferSize: usize ) -> Result<Self, ArchiveError> {
         let fname = CString::new(fileName).unwrap();
         unsafe {
             let res = archive_read_open_filename(*self.handler, fname.as_ptr(), bufferSize);
@@ -266,7 +265,7 @@ impl Reader {
     pub fn open_memory(self, memory: &mut [u8]) -> Result<Self, ArchiveError> {
         unsafe {
             let memptr: *mut u8 = &mut memory[0];
-            let res = archive_read_open_memory(*self.handler, memptr as *mut c_void, memory.len() as u64);
+            let res = archive_read_open_memory(*self.handler, memptr as *mut c_void, memory.len() as usize);
             if res==ARCHIVE_OK {
                 Ok(self)
             } else {
@@ -457,7 +456,7 @@ impl Writer {
   pub fn open_memory(&mut self, memory: &mut [u8]) -> Result<&mut Self, ArchiveError> {
       unsafe {
           let memptr: *mut u8 = &mut memory[0];
-          let res = archive_write_open_memory(*self.handler, memptr as *mut c_void, memory.len() as u64, *self.outUsed);
+          let res = archive_write_open_memory(*self.handler, memptr as *mut c_void, memory.len() as usize, *self.outUsed);
           if res==ARCHIVE_OK {
               Ok(self)
           } else {
@@ -496,7 +495,7 @@ impl Writer {
         let data_len = data.len();
         let data_bytes = CString::from_vec_unchecked(data);
         // TODO: How to handle errors here?
-        archive_write_data(*self.handler, data_bytes.as_ptr() as *mut c_void, data_len as u64);
+        archive_write_data(*self.handler, data_bytes.as_ptr() as *mut c_void, data_len as usize);
       }
       Ok(self)
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,7 +222,6 @@ impl Reader {
                 Err(AllocationError)
             } else {
                 Ok(Reader { handler: Rc::new(h) })
-
             }
         }
     }
@@ -321,6 +320,14 @@ impl Reader {
           }
         }
     }
+}
+
+impl Drop for ArchiveEntryReader {
+  fn drop(&mut self) {
+    if Rc::is_unique(&self.handler) {
+      unsafe { archive_read_free(*self.handler); }
+    }
+  }
 }
 
 impl Drop for Reader {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,32 +1,29 @@
-
 #![feature(libc)]
-
 //for debug purpose
 #![allow(dead_code)]
 #![allow(non_snake_case)]
 #![allow(non_camel_case_types)]
 #![feature(trace_macros)]
 #![feature(concat_idents)]
+#![feature(rustc_private)]
 
 mod ffi;
 use ffi::archive::*;
 
-use std::ptr;
-use std::ffi::CString;
-use std::ffi::CStr;
-use std::rc::Rc;
-use std::io::{Read, Seek};
-use std::error::Error;
 use std::any::Any;
-
+use std::error::Error;
+use std::ffi::CStr;
+use std::ffi::CString;
+use std::io::{Read, Seek};
+use std::ptr;
+use std::rc::Rc;
 
 extern crate time;
 use time::Timespec;
 
-
 #[derive(PartialEq, Clone)]
 pub struct Reader {
-    handler: Rc<*mut Struct_archive>
+    handler: Rc<*mut Struct_archive>,
 }
 
 #[derive(Debug)]
@@ -38,7 +35,7 @@ pub enum ArchiveError {
     Failed,
     Retry,
     Eof,
-    Fatal
+    Fatal,
 }
 #[derive(Debug)]
 pub enum ArchiveExtractFlag {
@@ -58,7 +55,7 @@ pub enum ArchiveExtractFlag {
     Mac_Metadata,
     No_Hfs_Compression,
     Hfs_Compression_Forced,
-    Secure_Noabsolutepaths
+    Secure_Noabsolutepaths,
 }
 
 pub enum ArchiveFormat {
@@ -78,33 +75,33 @@ pub enum ArchiveFormat {
     Ustar,
     // V7tar,
     Xar,
-    Zip
+    Zip,
 }
 
 pub enum ArchiveFilter {
-  Bzip2,
-  Compress,
-  Gzip,
-  Lzip,
-  Lzma,
-  None,
-  // TODO : Program(&str)
-  Xz
+    Bzip2,
+    Compress,
+    Gzip,
+    Lzip,
+    Lzma,
+    None,
+    // TODO : Program(&str)
+    Xz,
 }
 pub enum ArchiveEntryIOType {
-  ReaderEntry,
-  WriterEntry
+    ReaderEntry,
+    WriterEntry,
 }
 
 pub enum ArchiveEntryFiletype {
-  AE_IFMT  ,
-  AE_IFREG ,
-  AE_IFLNK ,
-  AE_IFSOCK,
-  AE_IFCHR ,
-  AE_IFBLK ,
-  AE_IFDIR ,
-  AE_IFIFO
+    AE_IFMT,
+    AE_IFREG,
+    AE_IFLNK,
+    AE_IFSOCK,
+    AE_IFCHR,
+    AE_IFBLK,
+    AE_IFDIR,
+    AE_IFIFO,
 }
 /*
 impl fmt::Debug for AllocationError {
@@ -119,42 +116,55 @@ impl fmt::Debug for AllocationError {
     }
 }*/
 
-
 fn code_to_error(code: c_int) -> ArchiveError {
     match code {
-        ARCHIVE_OK => { return ArchiveError::Ok; }
-        ARCHIVE_WARN => { return ArchiveError::Warn; }
-        ARCHIVE_FAILED => { return ArchiveError::Failed; }
-        ARCHIVE_RETRY => { return ArchiveError::Retry; }
-        ARCHIVE_EOF => { return ArchiveError::Eof; }
-        ARCHIVE_FATAL => { return ArchiveError::Fatal; }
-        _ => { panic!(); }
+        ARCHIVE_OK => {
+            return ArchiveError::Ok;
+        }
+        ARCHIVE_WARN => {
+            return ArchiveError::Warn;
+        }
+        ARCHIVE_FAILED => {
+            return ArchiveError::Failed;
+        }
+        ARCHIVE_RETRY => {
+            return ArchiveError::Retry;
+        }
+        ARCHIVE_EOF => {
+            return ArchiveError::Eof;
+        }
+        ARCHIVE_FATAL => {
+            return ArchiveError::Fatal;
+        }
+        _ => {
+            panic!();
+        }
     }
 }
 
-fn flags_to_code(flags : Vec<ArchiveExtractFlag>) -> c_int {
-    let mut flags_code : c_int = 0;
+fn flags_to_code(flags: Vec<ArchiveExtractFlag>) -> c_int {
+    let mut flags_code: c_int = 0;
     for flag in flags.into_iter() {
-      let flag_code : c_int = match flag {
-          ArchiveExtractFlag::Owner => ARCHIVE_EXTRACT_OWNER,
-          ArchiveExtractFlag::Perm => ARCHIVE_EXTRACT_PERM,
-          ArchiveExtractFlag::Time => ARCHIVE_EXTRACT_TIME,
-          ArchiveExtractFlag::No_Overwrite => ARCHIVE_EXTRACT_NO_OVERWRITE,
-          ArchiveExtractFlag::Unlink => ARCHIVE_EXTRACT_UNLINK,
-          ArchiveExtractFlag::Acl => ARCHIVE_EXTRACT_ACL,
-          ArchiveExtractFlag::Fflags => ARCHIVE_EXTRACT_FFLAGS,
-          ArchiveExtractFlag::Xattr => ARCHIVE_EXTRACT_XATTR,
-          ArchiveExtractFlag::Secure_Symlinks => ARCHIVE_EXTRACT_SECURE_SYMLINKS,
-          ArchiveExtractFlag::Secure_Nodotdot => ARCHIVE_EXTRACT_SECURE_NODOTDOT,
-          ArchiveExtractFlag::No_Autodir => ARCHIVE_EXTRACT_NO_AUTODIR,
-          ArchiveExtractFlag::No_Overwrite_Newer => ARCHIVE_EXTRACT_NO_OVERWRITE_NEWER,
-          ArchiveExtractFlag::Sparse => ARCHIVE_EXTRACT_SPARSE,
-          ArchiveExtractFlag::Mac_Metadata => ARCHIVE_EXTRACT_MAC_METADATA,
-          ArchiveExtractFlag::No_Hfs_Compression => ARCHIVE_EXTRACT_NO_HFS_COMPRESSION,
-          ArchiveExtractFlag::Hfs_Compression_Forced => ARCHIVE_EXTRACT_HFS_COMPRESSION_FORCED,
-          ArchiveExtractFlag::Secure_Noabsolutepaths => ARCHIVE_EXTRACT_SECURE_NOABSOLUTEPATHS
-      };
-      flags_code |= flag_code;
+        let flag_code: c_int = match flag {
+            ArchiveExtractFlag::Owner => ARCHIVE_EXTRACT_OWNER,
+            ArchiveExtractFlag::Perm => ARCHIVE_EXTRACT_PERM,
+            ArchiveExtractFlag::Time => ARCHIVE_EXTRACT_TIME,
+            ArchiveExtractFlag::No_Overwrite => ARCHIVE_EXTRACT_NO_OVERWRITE,
+            ArchiveExtractFlag::Unlink => ARCHIVE_EXTRACT_UNLINK,
+            ArchiveExtractFlag::Acl => ARCHIVE_EXTRACT_ACL,
+            ArchiveExtractFlag::Fflags => ARCHIVE_EXTRACT_FFLAGS,
+            ArchiveExtractFlag::Xattr => ARCHIVE_EXTRACT_XATTR,
+            ArchiveExtractFlag::Secure_Symlinks => ARCHIVE_EXTRACT_SECURE_SYMLINKS,
+            ArchiveExtractFlag::Secure_Nodotdot => ARCHIVE_EXTRACT_SECURE_NODOTDOT,
+            ArchiveExtractFlag::No_Autodir => ARCHIVE_EXTRACT_NO_AUTODIR,
+            ArchiveExtractFlag::No_Overwrite_Newer => ARCHIVE_EXTRACT_NO_OVERWRITE_NEWER,
+            ArchiveExtractFlag::Sparse => ARCHIVE_EXTRACT_SPARSE,
+            ArchiveExtractFlag::Mac_Metadata => ARCHIVE_EXTRACT_MAC_METADATA,
+            ArchiveExtractFlag::No_Hfs_Compression => ARCHIVE_EXTRACT_NO_HFS_COMPRESSION,
+            ArchiveExtractFlag::Hfs_Compression_Forced => ARCHIVE_EXTRACT_HFS_COMPRESSION_FORCED,
+            ArchiveExtractFlag::Secure_Noabsolutepaths => ARCHIVE_EXTRACT_SECURE_NOABSOLUTEPATHS,
+        };
+        flags_code |= flag_code;
     }
     flags_code
 }
@@ -162,7 +172,7 @@ fn flags_to_code(flags : Vec<ArchiveExtractFlag>) -> c_int {
 struct ReadContainer {
     reader: Box<Read>,
     buffer: Vec<u8>,
-    seeker: Option<Box<Seek>>
+    seeker: Option<Box<Seek>>,
 }
 
 impl ReadContainer {
@@ -171,7 +181,11 @@ impl ReadContainer {
     }
 }
 
-extern "C" fn arch_read(arch: *mut Struct_archive, _client_data: *mut c_void, _buffer: *mut *mut c_void) -> ssize_t {
+extern "C" fn arch_read(
+    arch: *mut Struct_archive,
+    _client_data: *mut c_void,
+    _buffer: *mut *mut c_void,
+) -> ssize_t {
     unsafe {
         // use client_data as pointer to ReadContainer struct
         let mut rc = Box::from_raw(_client_data as *mut ReadContainer);
@@ -197,7 +211,11 @@ extern "C" fn arch_close(arch: *mut Struct_archive, _client_data: *mut c_void) -
     }
 }
 
-extern "C" fn arch_skip(_: *mut Struct_archive, _client_data: *mut c_void, request: int64_t) -> int64_t {
+extern "C" fn arch_skip(
+    _: *mut Struct_archive,
+    _client_data: *mut c_void,
+    request: int64_t,
+) -> int64_t {
     unsafe {
         let mut rc = Box::from_raw(_client_data as *mut ReadContainer);
 
@@ -206,7 +224,12 @@ extern "C" fn arch_skip(_: *mut Struct_archive, _client_data: *mut c_void, reque
             Box::into_raw(rc);
             return 0;
         }
-        let size = rc.seeker.as_mut().unwrap().seek(std::io::SeekFrom::Current(request)).unwrap_or(0);
+        let size = rc
+            .seeker
+            .as_mut()
+            .unwrap()
+            .seek(std::io::SeekFrom::Current(request))
+            .unwrap_or(0);
 
         Box::into_raw(rc);
         return size as int64_t;
@@ -221,7 +244,9 @@ impl Reader {
             if h.is_null() {
                 Err(AllocationError)
             } else {
-                Ok(Reader { handler: Rc::new(h) })
+                Ok(Reader {
+                    handler: Rc::new(h),
+                })
             }
         }
     }
@@ -246,12 +271,11 @@ impl Reader {
         self
     }
 
-
-    pub fn open_filename(self, fileName: &str, bufferSize: usize ) -> Result<Self, ArchiveError> {
+    pub fn open_filename(self, fileName: &str, bufferSize: usize) -> Result<Self, ArchiveError> {
         let fname = CString::new(fileName).unwrap();
         unsafe {
             let res = archive_read_open_filename(*self.handler, fname.as_ptr(), bufferSize);
-            if res==ARCHIVE_OK {
+            if res == ARCHIVE_OK {
                 Ok(self)
             } else {
                 Err(code_to_error(res))
@@ -262,8 +286,12 @@ impl Reader {
     pub fn open_memory(self, memory: &mut [u8]) -> Result<Self, ArchiveError> {
         unsafe {
             let memptr: *mut u8 = &mut memory[0];
-            let res = archive_read_open_memory(*self.handler, memptr as *mut c_void, memory.len() as usize);
-            if res==ARCHIVE_OK {
+            let res = archive_read_open_memory(
+                *self.handler,
+                memptr as *mut c_void,
+                memory.len() as usize,
+            );
+            if res == ARCHIVE_OK {
                 Ok(self)
             } else {
                 Err(code_to_error(res))
@@ -271,21 +299,26 @@ impl Reader {
         }
     }
 
-    pub fn open_stream<T: Any+Read>(self, source: T) -> Result<Self, ArchiveError> {
+    pub fn open_stream<T: Any + Read>(self, source: T) -> Result<Self, ArchiveError> {
         unsafe {
-            let mut rc_unboxed =  ReadContainer { reader: Box::new(source), buffer: Vec::with_capacity(8192), seeker: None};
+            let mut rc_unboxed = ReadContainer {
+                reader: Box::new(source),
+                buffer: Vec::with_capacity(8192),
+                seeker: None,
+            };
             for _ in 0..8192 {
                 rc_unboxed.buffer.push(0);
             }
-            let rc = Box::new( rc_unboxed );
+            let rc = Box::new(rc_unboxed);
 
             let res = archive_read_open(
-                        *self.handler,
-                        Box::into_raw(rc) as *mut c_void,
-                        ptr::null_mut(),
-                        arch_read,
-                        arch_close);
-            if res==ARCHIVE_OK {
+                *self.handler,
+                Box::into_raw(rc) as *mut c_void,
+                ptr::null_mut(),
+                arch_read,
+                arch_close,
+            );
+            if res == ARCHIVE_OK {
                 Ok(self)
             } else {
                 Err(code_to_error(res))
@@ -298,249 +331,277 @@ impl Reader {
         unsafe {
             let mut entry: *mut Struct_archive_entry = ptr::null_mut();
             let res = archive_read_next_header(*self.handler, &mut entry);
-            if res==ARCHIVE_OK {
-                Ok( ArchiveEntryReader { entry: entry, handler: self.handler.clone(), iotype: ReaderEntry } )
+            if res == ARCHIVE_OK {
+                Ok(ArchiveEntryReader {
+                    entry: entry,
+                    handler: self.handler.clone(),
+                    iotype: ReaderEntry,
+                })
             } else {
                 Err(code_to_error(res))
             }
         }
     }
 
-    pub fn read_data<'s>(&'s self, size : size_t) -> Result<Vec<u8>, ArchiveError> {
+    pub fn read_data<'s>(&'s self, size: size_t) -> Result<Vec<u8>, ArchiveError> {
         unsafe {
-          let mut chunk_vec = Vec::with_capacity(size as usize);
-          let chunk_ptr = chunk_vec.as_mut_ptr();
-          let res = archive_read_data(*self.handler, chunk_ptr as *mut c_void, size) as i32;
-          if (res==ARCHIVE_FATAL) || (res==ARCHIVE_WARN) || (res==ARCHIVE_RETRY) {
-            Err(code_to_error(res))
-          } else if res==0 {
-            Err(code_to_error(ARCHIVE_EOF))
-          } else {
-            chunk_vec.set_len(res as usize);
-            Ok(chunk_vec)
-          }
+            let mut chunk_vec = Vec::with_capacity(size as usize);
+            let chunk_ptr = chunk_vec.as_mut_ptr();
+            let res = archive_read_data(*self.handler, chunk_ptr as *mut c_void, size) as i32;
+            if (res == ARCHIVE_FATAL) || (res == ARCHIVE_WARN) || (res == ARCHIVE_RETRY) {
+                Err(code_to_error(res))
+            } else if res == 0 {
+                Err(code_to_error(ARCHIVE_EOF))
+            } else {
+                chunk_vec.set_len(res as usize);
+                Ok(chunk_vec)
+            }
         }
     }
 }
 
 impl Drop for ArchiveEntryReader {
-  fn drop(&mut self) {
-    use ArchiveEntryIOType::*;
-    if Rc::strong_count(&self.handler) <= 1 {
-      match self.iotype {
-        ReaderEntry => unsafe {
-          archive_read_close(*self.handler);
-          archive_read_free(*self.handler); },
-        WriterEntry => unsafe {
-          archive_write_close(*self.handler);
-          archive_write_free(*self.handler);
+    fn drop(&mut self) {
+        use ArchiveEntryIOType::*;
+        if Rc::strong_count(&self.handler) <= 1 {
+            match self.iotype {
+                ReaderEntry => unsafe {
+                    archive_read_close(*self.handler);
+                    archive_read_free(*self.handler);
+                },
+                WriterEntry => unsafe {
+                    archive_write_close(*self.handler);
+                    archive_write_free(*self.handler);
+                },
+            }
         }
-      }
     }
-  }
 }
 
 impl Drop for Reader {
-	fn drop(&mut self) {
-		if Rc::strong_count(&self.handler) <= 1 {
-			unsafe {
-        archive_read_close(*self.handler);
-        archive_read_free(*self.handler);
-      }
-		}
-	}
+    fn drop(&mut self) {
+        if Rc::strong_count(&self.handler) <= 1 {
+            unsafe {
+                archive_read_close(*self.handler);
+                archive_read_free(*self.handler);
+            }
+        }
+    }
 }
 
 #[derive(PartialEq, Clone)]
 pub struct Writer {
-	handler: Rc<*mut Struct_archive>,
-  outUsed : Rc<*mut size_t>
+    handler: Rc<*mut Struct_archive>,
+    outUsed: Rc<*mut size_t>,
 }
 
 impl Drop for Writer {
-	fn drop(&mut self) {
-		if Rc::strong_count(&self.handler) <= 1 {
-			unsafe {
-        archive_write_close(*self.handler);
-        archive_write_free(*self.handler);
-      }
-		}
-	}
+    fn drop(&mut self) {
+        if Rc::strong_count(&self.handler) <= 1 {
+            unsafe {
+                archive_write_close(*self.handler);
+                archive_write_free(*self.handler);
+            }
+        }
+    }
 }
 
 impl Writer {
-	pub fn new() -> Result<Writer, AllocationError> {
-		unsafe {
-			let h = archive_write_new();
-			if h.is_null() {
-				Err(AllocationError)
-			} else {
-        let mut init_used: Box<size_t> = Box::new(0);
-        let outUsed: *mut size_t = &mut *init_used;
-				Ok(Writer { handler: Rc::new(h), outUsed: Rc::new(outUsed)})
-			}
-		}
-	}
-  pub fn add_filter(self, filter : ArchiveFilter) -> Self {
-    unsafe {
-      match filter {
-        ArchiveFilter::Bzip2 => archive_write_add_filter_bzip2(*self.handler),
-        ArchiveFilter::Compress => archive_write_add_filter_compress(*self.handler),
-        ArchiveFilter::Gzip => archive_write_add_filter_gzip(*self.handler),
-        ArchiveFilter::Lzip => archive_write_add_filter_lzip(*self.handler),
-        ArchiveFilter::Lzma => archive_write_add_filter_lzma(*self.handler),
-        ArchiveFilter::None => archive_write_add_filter_none(*self.handler),
-        // TODO : Program(&str)
-        ArchiveFilter::Xz => archive_write_add_filter_xz(*self.handler)
-      };
-    }
-    self
-  }
-
-  pub fn set_format(self, format : ArchiveFormat) -> Self {
-    unsafe {
-      match format {
-        ArchiveFormat::_7Zip => archive_write_set_format_7zip(*self.handler),
-        ArchiveFormat::Ar_Bsd => archive_write_set_format_ar_bsd(*self.handler),
-        ArchiveFormat::Ar_Svr4 => archive_write_set_format_ar_svr4(*self.handler),
-        ArchiveFormat::Cpio => archive_write_set_format_cpio(*self.handler),
-        ArchiveFormat::Cpio_newc => archive_write_set_format_cpio_newc(*self.handler),
-        ArchiveFormat::Gnutar => archive_write_set_format_gnutar(*self.handler),
-        ArchiveFormat::Iso9600 => archive_write_set_format_iso9660(*self.handler),
-        ArchiveFormat::Mtree => archive_write_set_format_mtree(*self.handler),
-        // ArchiveFormat::Mtree_Classic => archive_write_set_format_mtree_classic(*self.handler),
-        ArchiveFormat::Pax => archive_write_set_format_pax(*self.handler),
-        ArchiveFormat::Pax_Restricted => archive_write_set_format_pax_restricted(*self.handler),
-        ArchiveFormat::Shar => archive_write_set_format_shar(*self.handler),
-        ArchiveFormat::Shar_Dump => archive_write_set_format_shar_dump(*self.handler),
-        ArchiveFormat::Ustar => archive_write_set_format_ustar(*self.handler),
-        // ArchiveFormat::V7tar => archive_write_set_format_v7tar(*self.handler),
-        ArchiveFormat::Xar => archive_write_set_format_xar(*self.handler),
-        ArchiveFormat::Zip => archive_write_set_format_zip(*self.handler),
-      };
-    }
-    self
-  }
-
-  pub fn set_compression(self, filter : ArchiveFilter) -> Self {
-    unsafe {
-      match filter {
-        ArchiveFilter::Bzip2 => archive_write_set_compression_bzip2(*self.handler),
-        ArchiveFilter::Compress => archive_write_set_compression_compress(*self.handler),
-        ArchiveFilter::Gzip => archive_write_set_compression_gzip(*self.handler),
-        ArchiveFilter::Lzip => archive_write_set_compression_lzip(*self.handler),
-        ArchiveFilter::Lzma => archive_write_set_compression_lzma(*self.handler),
-        ArchiveFilter::None => archive_write_set_compression_none(*self.handler),
-        ArchiveFilter::Xz => archive_write_set_compression_xz(*self.handler)
-      };
-    }
-    self
-  }
-
-  pub fn open_filename(&mut self, fileName: &str) -> Result<&mut Self, ArchiveError> {
-      let fname = CString::new(fileName).unwrap();
-      unsafe {
-          let res = archive_write_open_filename(*self.handler, fname.as_ptr());
-          if res==ARCHIVE_OK {
-              Ok(self)
-          } else {
-              Err(code_to_error(res))
-          }
-      }
-  }
-
-  pub fn open_memory(&mut self, memory: &mut [u8]) -> Result<&mut Self, ArchiveError> {
-      unsafe {
-          let memptr: *mut u8 = &mut memory[0];
-          let res = archive_write_open_memory(*self.handler, memptr as *mut c_void, memory.len() as usize, *self.outUsed);
-          if res==ARCHIVE_OK {
-              Ok(self)
-          } else {
-              Err(code_to_error(res))
-          }
-      }
-  }
-
-  pub fn write_header(&mut self, entry: ArchiveEntryReader) -> Result<&mut Self, ArchiveError> {
-      unsafe {
-        let res = archive_write_header(*self.handler, entry.entry);
-        if res==ARCHIVE_OK {
-            Ok(self)
-        } else {
-            Err(code_to_error(res))
+    pub fn new() -> Result<Writer, AllocationError> {
+        unsafe {
+            let h = archive_write_new();
+            if h.is_null() {
+                Err(AllocationError)
+            } else {
+                let mut init_used: Box<size_t> = Box::new(0);
+                let outUsed: *mut size_t = &mut *init_used;
+                Ok(Writer {
+                    handler: Rc::new(h),
+                    outUsed: Rc::new(outUsed),
+                })
+            }
         }
-      }
-  }
-
-  pub fn write_header_new(&mut self, pathname: &str, entry_size: i64) -> Result<&mut Self, ArchiveError> {
-      use ArchiveEntryIOType::*;
-      unsafe {
-        let new_entry = archive_entry_new();
-        archive_entry_set_perm(new_entry, 0o755);
-        archive_entry_set_size(new_entry, entry_size);
-        let entry = ArchiveEntryReader { entry: new_entry, handler: self.handler.clone(), iotype: WriterEntry };
-        entry.set_filetype(ArchiveEntryFiletype::AE_IFREG);
-        entry.set_pathname(pathname);
-
-        self.write_header(entry)
-      }
-  }
-
-  pub fn write_data(&mut self, data: Vec<u8>) -> Result<&mut Self, ArchiveError> {
-      unsafe {
-        let data_len = data.len();
-        let data_bytes = CString::from_vec_unchecked(data);
-        // TODO: How to handle errors here?
-        archive_write_data(*self.handler, data_bytes.as_ptr() as *mut c_void, data_len as usize);
-      }
-      Ok(self)
-  }
-  pub fn write_finish_entry(&mut self) -> Result<&mut Self, ArchiveError> {
-      unsafe {
-        let res = archive_write_finish_entry(*self.handler);
-        if res==ARCHIVE_OK {
-            Ok(self)
-        } else {
-            Err(code_to_error(res))
+    }
+    pub fn add_filter(self, filter: ArchiveFilter) -> Self {
+        unsafe {
+            match filter {
+                ArchiveFilter::Bzip2 => archive_write_add_filter_bzip2(*self.handler),
+                ArchiveFilter::Compress => archive_write_add_filter_compress(*self.handler),
+                ArchiveFilter::Gzip => archive_write_add_filter_gzip(*self.handler),
+                ArchiveFilter::Lzip => archive_write_add_filter_lzip(*self.handler),
+                ArchiveFilter::Lzma => archive_write_add_filter_lzma(*self.handler),
+                ArchiveFilter::None => archive_write_add_filter_none(*self.handler),
+                // TODO : Program(&str)
+                ArchiveFilter::Xz => archive_write_add_filter_xz(*self.handler),
+            };
         }
-      }
-  }
+        self
+    }
 
+    pub fn set_format(self, format: ArchiveFormat) -> Self {
+        unsafe {
+            match format {
+                ArchiveFormat::_7Zip => archive_write_set_format_7zip(*self.handler),
+                ArchiveFormat::Ar_Bsd => archive_write_set_format_ar_bsd(*self.handler),
+                ArchiveFormat::Ar_Svr4 => archive_write_set_format_ar_svr4(*self.handler),
+                ArchiveFormat::Cpio => archive_write_set_format_cpio(*self.handler),
+                ArchiveFormat::Cpio_newc => archive_write_set_format_cpio_newc(*self.handler),
+                ArchiveFormat::Gnutar => archive_write_set_format_gnutar(*self.handler),
+                ArchiveFormat::Iso9600 => archive_write_set_format_iso9660(*self.handler),
+                ArchiveFormat::Mtree => archive_write_set_format_mtree(*self.handler),
+                // ArchiveFormat::Mtree_Classic => archive_write_set_format_mtree_classic(*self.handler),
+                ArchiveFormat::Pax => archive_write_set_format_pax(*self.handler),
+                ArchiveFormat::Pax_Restricted => {
+                    archive_write_set_format_pax_restricted(*self.handler)
+                }
+                ArchiveFormat::Shar => archive_write_set_format_shar(*self.handler),
+                ArchiveFormat::Shar_Dump => archive_write_set_format_shar_dump(*self.handler),
+                ArchiveFormat::Ustar => archive_write_set_format_ustar(*self.handler),
+                // ArchiveFormat::V7tar => archive_write_set_format_v7tar(*self.handler),
+                ArchiveFormat::Xar => archive_write_set_format_xar(*self.handler),
+                ArchiveFormat::Zip => archive_write_set_format_zip(*self.handler),
+            };
+        }
+        self
+    }
+
+    pub fn set_compression(self, filter: ArchiveFilter) -> Self {
+        unsafe {
+            match filter {
+                ArchiveFilter::Bzip2 => archive_write_set_compression_bzip2(*self.handler),
+                ArchiveFilter::Compress => archive_write_set_compression_compress(*self.handler),
+                ArchiveFilter::Gzip => archive_write_set_compression_gzip(*self.handler),
+                ArchiveFilter::Lzip => archive_write_set_compression_lzip(*self.handler),
+                ArchiveFilter::Lzma => archive_write_set_compression_lzma(*self.handler),
+                ArchiveFilter::None => archive_write_set_compression_none(*self.handler),
+                ArchiveFilter::Xz => archive_write_set_compression_xz(*self.handler),
+            };
+        }
+        self
+    }
+
+    pub fn open_filename(&mut self, fileName: &str) -> Result<&mut Self, ArchiveError> {
+        let fname = CString::new(fileName).unwrap();
+        unsafe {
+            let res = archive_write_open_filename(*self.handler, fname.as_ptr());
+            if res == ARCHIVE_OK {
+                Ok(self)
+            } else {
+                Err(code_to_error(res))
+            }
+        }
+    }
+
+    pub fn open_memory(&mut self, memory: &mut [u8]) -> Result<&mut Self, ArchiveError> {
+        unsafe {
+            let memptr: *mut u8 = &mut memory[0];
+            let res = archive_write_open_memory(
+                *self.handler,
+                memptr as *mut c_void,
+                memory.len() as usize,
+                *self.outUsed,
+            );
+            if res == ARCHIVE_OK {
+                Ok(self)
+            } else {
+                Err(code_to_error(res))
+            }
+        }
+    }
+
+    pub fn write_header(&mut self, entry: ArchiveEntryReader) -> Result<&mut Self, ArchiveError> {
+        unsafe {
+            let res = archive_write_header(*self.handler, entry.entry);
+            if res == ARCHIVE_OK {
+                Ok(self)
+            } else {
+                Err(code_to_error(res))
+            }
+        }
+    }
+
+    pub fn write_header_new(
+        &mut self,
+        pathname: &str,
+        entry_size: i64,
+    ) -> Result<&mut Self, ArchiveError> {
+        use ArchiveEntryIOType::*;
+        unsafe {
+            let new_entry = archive_entry_new();
+            archive_entry_set_perm(new_entry, 0o755);
+            archive_entry_set_size(new_entry, entry_size);
+            let entry = ArchiveEntryReader {
+                entry: new_entry,
+                handler: self.handler.clone(),
+                iotype: WriterEntry,
+            };
+            entry.set_filetype(ArchiveEntryFiletype::AE_IFREG);
+            entry.set_pathname(pathname);
+
+            self.write_header(entry)
+        }
+    }
+
+    pub fn write_data(&mut self, data: Vec<u8>) -> Result<&mut Self, ArchiveError> {
+        unsafe {
+            let data_len = data.len();
+            let data_bytes = CString::from_vec_unchecked(data);
+            // TODO: How to handle errors here?
+            archive_write_data(
+                *self.handler,
+                data_bytes.as_ptr() as *mut c_void,
+                data_len as usize,
+            );
+        }
+        Ok(self)
+    }
+    pub fn write_finish_entry(&mut self) -> Result<&mut Self, ArchiveError> {
+        unsafe {
+            let res = archive_write_finish_entry(*self.handler);
+            if res == ARCHIVE_OK {
+                Ok(self)
+            } else {
+                Err(code_to_error(res))
+            }
+        }
+    }
 }
 
 #[derive(PartialEq, Clone)]
 pub struct WriterToDisk {
-	handler: Rc<*mut Struct_archive>
+    handler: Rc<*mut Struct_archive>,
 }
 
 impl WriterToDisk {
-	pub fn new() -> Result<WriterToDisk, AllocationError> {
-		unsafe {
-			let h = archive_write_disk_new();
-			if h.is_null() {
-					Err(AllocationError)
-			} else {
-					Ok(WriterToDisk { handler: Rc::new(h) })
-			}
-		}
-	}
+    pub fn new() -> Result<WriterToDisk, AllocationError> {
+        unsafe {
+            let h = archive_write_disk_new();
+            if h.is_null() {
+                Err(AllocationError)
+            } else {
+                Ok(WriterToDisk {
+                    handler: Rc::new(h),
+                })
+            }
+        }
+    }
 }
 
 impl Drop for WriterToDisk {
-	fn drop(&mut self) {
-		if Rc::strong_count(&self.handler) <= 1 {
-			unsafe {
-        archive_write_close(*self.handler);
-        archive_write_free(*self.handler);
-      }
-		}
-	}
+    fn drop(&mut self) {
+        if Rc::strong_count(&self.handler) <= 1 {
+            unsafe {
+                archive_write_close(*self.handler);
+                archive_write_free(*self.handler);
+            }
+        }
+    }
 }
 
 pub struct ArchiveEntryReader {
     entry: *mut Struct_archive_entry,
     handler: Rc<*mut Struct_archive>,
-    iotype: ArchiveEntryIOType
+    iotype: ArchiveEntryIOType,
 }
 
 macro_rules! get_time {
@@ -562,72 +623,70 @@ unsafe fn wrap_to_string(ptr: *const c_char) -> String {
 
 impl ArchiveEntryReader {
     pub fn size(&self) -> i64 {
-      unsafe {
-        archive_entry_size(self.entry)
-      }
+        unsafe { archive_entry_size(self.entry) }
     }
 
     pub fn pathname(&self) -> String {
-        unsafe {
-            wrap_to_string(archive_entry_pathname(self.entry))
-        }
+        unsafe { wrap_to_string(archive_entry_pathname(self.entry)) }
     }
 
     pub fn sourcepath(&self) -> String {
-        unsafe {
-            wrap_to_string(archive_entry_sourcepath(self.entry))
-        }
+        unsafe { wrap_to_string(archive_entry_sourcepath(self.entry)) }
     }
 
     pub fn set_filetype(&self, filetype: ArchiveEntryFiletype) {
-      let c_type = match filetype {
-        ArchiveEntryFiletype::AE_IFMT   => 0o170000,
-        ArchiveEntryFiletype::AE_IFREG  => 0o100000,
-        ArchiveEntryFiletype::AE_IFLNK  => 0o120000,
-        ArchiveEntryFiletype::AE_IFSOCK => 0o140000,
-        ArchiveEntryFiletype::AE_IFCHR  => 0o020000,
-        ArchiveEntryFiletype::AE_IFBLK  => 0o060000,
-        ArchiveEntryFiletype::AE_IFDIR  => 0o040000,
-        ArchiveEntryFiletype::AE_IFIFO  => 0o010000
-      };
-      unsafe {
-        archive_entry_set_filetype(self.entry, c_type);
-      }
+        let c_type = match filetype {
+            ArchiveEntryFiletype::AE_IFMT => 0o170000,
+            ArchiveEntryFiletype::AE_IFREG => 0o100000,
+            ArchiveEntryFiletype::AE_IFLNK => 0o120000,
+            ArchiveEntryFiletype::AE_IFSOCK => 0o140000,
+            ArchiveEntryFiletype::AE_IFCHR => 0o020000,
+            ArchiveEntryFiletype::AE_IFBLK => 0o060000,
+            ArchiveEntryFiletype::AE_IFDIR => 0o040000,
+            ArchiveEntryFiletype::AE_IFIFO => 0o010000,
+        };
+        unsafe {
+            archive_entry_set_filetype(self.entry, c_type);
+        }
     }
 
     pub fn set_pathname(&self, pathname: &str) {
-      let c_pathname = CString::new(pathname).unwrap();
-      unsafe {
-        archive_entry_set_pathname(self.entry, c_pathname.as_ptr());
-      }
+        let c_pathname = CString::new(pathname).unwrap();
+        unsafe {
+            archive_entry_set_pathname(self.entry, c_pathname.as_ptr());
+        }
     }
 
     pub fn archive(&self) -> Reader {
-        Reader { handler: self.handler.clone() }
+        Reader {
+            handler: self.handler.clone(),
+        }
     }
 
-    pub fn extract_to(self, path : &str, flags : Vec<ArchiveExtractFlag>) -> Result<Self, ArchiveError> {
+    pub fn extract_to(
+        self,
+        path: &str,
+        flags: Vec<ArchiveExtractFlag>,
+    ) -> Result<Self, ArchiveError> {
         let extract_path = CString::new(path).unwrap();
         unsafe {
             archive_entry_set_pathname(self.entry, extract_path.as_ptr());
             self.extract(flags)
         }
     }
-    pub fn extract(self,flags : Vec<ArchiveExtractFlag>) -> Result<Self, ArchiveError> {
+    pub fn extract(self, flags: Vec<ArchiveExtractFlag>) -> Result<Self, ArchiveError> {
         unsafe {
-          let res = archive_read_extract(*self.handler, self.entry, flags_to_code(flags));
-          if res==ARCHIVE_OK {
-              Ok(self)
-          } else {
-            Err(code_to_error(res))
-          }
+            let res = archive_read_extract(*self.handler, self.entry, flags_to_code(flags));
+            if res == ARCHIVE_OK {
+                Ok(self)
+            } else {
+                Err(code_to_error(res))
+            }
         }
     }
-
 
     get_time!(access_time, atime);
     get_time!(creation_time, birthtime);
     get_time!(inode_change_time, ctime);
     get_time!(modification_time, mtime);
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,6 @@ extern crate time;
 use time::Timespec;
 
 
-#[allow(raw_pointer_derive)]
 #[derive(PartialEq, Clone)]
 pub struct Reader {
     handler: Rc<*mut Struct_archive>
@@ -319,7 +318,7 @@ impl Reader {
           } else if res==0 {
             Err(code_to_error(ARCHIVE_EOF))
           } else {
-            chunk_vec.set_len(size as usize);
+            chunk_vec.set_len(res as usize);
             Ok(chunk_vec)
           }
         }
@@ -354,7 +353,6 @@ impl Drop for Reader {
 	}
 }
 
-#[allow(raw_pointer_derive)]
 #[derive(PartialEq, Clone)]
 pub struct Writer {
 	handler: Rc<*mut Struct_archive>,
@@ -512,7 +510,6 @@ impl Writer {
 
 }
 
-#[allow(raw_pointer_derive)]
 #[derive(PartialEq, Clone)]
 pub struct WriterToDisk {
 	handler: Rc<*mut Struct_archive>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -330,6 +330,7 @@ impl Reader {
 impl Drop for ArchiveEntryReader {
   fn drop(&mut self) {
     use ArchiveEntryIOType::*;
+    unsafe{ archive_entry_free(self.entry); }
     if Rc::is_unique(&self.handler) {
       match self.iotype {
         ReaderEntry => unsafe { archive_read_free(*self.handler); },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 
 #![feature(libc)]
-#![feature(is_unique)]
 
 //for debug purpose
 #![allow(dead_code)]
@@ -8,7 +7,6 @@
 #![allow(non_camel_case_types)]
 #![feature(trace_macros)]
 #![feature(concat_idents)]
-
 
 mod ffi;
 use ffi::archive::*;
@@ -328,7 +326,7 @@ impl Reader {
 impl Drop for ArchiveEntryReader {
   fn drop(&mut self) {
     use ArchiveEntryIOType::*;
-    if Rc::is_unique(&self.handler) {
+    if Rc::strong_count(&self.handler) <= 1 {
       match self.iotype {
         ReaderEntry => unsafe {
           archive_read_close(*self.handler);
@@ -344,7 +342,7 @@ impl Drop for ArchiveEntryReader {
 
 impl Drop for Reader {
 	fn drop(&mut self) {
-		if Rc::is_unique(&self.handler) {
+		if Rc::strong_count(&self.handler) <= 1 {
 			unsafe {
         archive_read_close(*self.handler);
         archive_read_free(*self.handler);
@@ -361,7 +359,7 @@ pub struct Writer {
 
 impl Drop for Writer {
 	fn drop(&mut self) {
-		if Rc::is_unique(&self.handler) {
+		if Rc::strong_count(&self.handler) <= 1 {
 			unsafe {
         archive_write_close(*self.handler);
         archive_write_free(*self.handler);
@@ -530,7 +528,7 @@ impl WriterToDisk {
 
 impl Drop for WriterToDisk {
 	fn drop(&mut self) {
-		if Rc::is_unique(&self.handler) {
+		if Rc::strong_count(&self.handler) <= 1 {
 			unsafe {
         archive_write_close(*self.handler);
         archive_write_free(*self.handler);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -330,7 +330,6 @@ impl Reader {
 impl Drop for ArchiveEntryReader {
   fn drop(&mut self) {
     use ArchiveEntryIOType::*;
-    unsafe{ archive_entry_free(self.entry); }
     if Rc::is_unique(&self.handler) {
       match self.iotype {
         ReaderEntry => unsafe { archive_read_free(*self.handler); },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 #![feature(trace_macros)]
 #![feature(concat_idents)]
 #![feature(box_raw)]
-#![feature(rc_unique)]
+#![feature(rc_counts)]
 
 
 mod ffi;


### PR DESCRIPTION
I am still quite uncomfortable maintaining a fork of this wrapper crate all of these years later, but it still saves time compared to refactoring all of my uses of libarchive to one of the alternatives.

For details of the unstable nightly change in v1.9 that required these changes, see:
https://github.com/rust-lang/rust/issues/124225